### PR TITLE
updates the search results count for both search and click on heatmap

### DIFF
--- a/src/components/Home/Map/IncidentFocus.js
+++ b/src/components/Home/Map/IncidentFocus.js
@@ -37,11 +37,11 @@ export default function IncidentFocus({ zoomOnCluster }) {
           <Panel
             className="collapseText"
             header={
-              clusterList.length === 0
+              queryList.length === 0
                 ? `Search for Results`
-                : activeList.length >= 1
+                : queryList.length >= 1 && clusterList.length >= 1
                 ? `Select to view ${activeList.length}+ Incidents`
-                : 'Search for Results'
+                : `Select to view ${activeList.length}+ Incidents`
             }
             bordered={false}
             style={{ color: 'white' }}


### PR DESCRIPTION
# Description

Fixes the issue where the incorrect count of search results would show after searching for incidents then clicking to a different location on the heatmap. Needed to target the queryList(for the search) and the clusterList(for the clicking on the heatmap).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] `npm test`
- [x] manually

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
